### PR TITLE
Close pr if cluster changes reverted

### DIFF
--- a/scripts/push_and_create_pr.sh
+++ b/scripts/push_and_create_pr.sh
@@ -64,7 +64,7 @@ else
             create_pr $branch $environment
         fi
     else
-        echo "Changes detected against main branch:"
+        echo "Changes detected against $branch branch:"
         echo "Deleting the remote branch $branch to close any existing PRs."
         create_pr $branch $environment
     fi


### PR DESCRIPTION
If a previous cluster change is gone, and the state is now equivalent to master, we should close existing pr for that env

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
