### PR TITLE
Add hmcts-dependency-updater as known git author

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,8 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "gitIgnoredAuthors": [
+        "104018155+hmcts-dependency-updater[bot]@users.noreply.github.com"
+    ],
     "extends": [
         "config:base",
         ":disableRateLimiting",


### PR DESCRIPTION
### Change description ###
Add hmcts-dependency-updater as known git author to avoid renovate being blocked when another but updates main branch.

![image](https://user-images.githubusercontent.com/40270505/207278614-5e494bec-c176-474a-9109-2df6f956227d.png)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
