### PR TITLE
Update bot config to hmcts-platform-operations

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "gitIgnoredAuthors": [
-        "104018155+hmcts-dependency-updater[bot]@users.noreply.github.com"
+        "77396727+hmcts-platform-operations@users.noreply.github.com"
     ],
     "extends": [
         "config:base",

--- a/scripts/push_and_create_pr.sh
+++ b/scripts/push_and_create_pr.sh
@@ -45,8 +45,8 @@ git fetch --all
 branch=yaml_autogenerate_$environment
 echo $gh_token | gh auth login --with-token
 
-git config --global user.email 104018155+hmcts-dependency-updater[bot]@users.noreply.github.com
-git config --global user.name hmcts-dependency-updater
+git config --global user.email 77396727+hmcts-platform-operations@users.noreply.github.com
+git config --global user.name hmcts-platform-operations
 
 # Temporary store file changes to checkout to local main branch
 


### PR DESCRIPTION
### Change description ###

Update bot config to use hmcts-platform-operations instead of hmcts-dependency-updater.

Correct email address for hmcts-platform-operations is `77396727+hmcts-platform-operations@users.noreply.github.com` as seen here https://github.com/hmcts/dynatrace-availability-dashboards/commit/5766e88f8993af6d3ab64e16ff887e9f9f205a80.patch

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
