### PR TITLE
Fail on incorrect env key

### DIFF
--- a/scripts/push_and_create_pr.sh
+++ b/scripts/push_and_create_pr.sh
@@ -21,11 +21,14 @@ create_pr(){
             | cut -d "/"  -f 7)
 
         gh pr merge --auto --delete-branch --squash $branch
+        # Fail if command from job returns non-zero exit code
+        set -e
         gh workflow --repo \
             hmcts/dynatrace-availability-dashboards \
             run auto-approve.yml \
             -f environment="$environment" \
             -f pr_number="$pr_number"
+        set +e
     else
         gh pr create \
             --title "$environment - Update YAML definitions" \


### PR DESCRIPTION
An error is quietly dropped here: 
![image](https://user-images.githubusercontent.com/47995122/207302181-b243981c-3b77-42d0-98c2-535f4da9dcba.png)

We want this to fail the job instead


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
