### PR TITLE
Debug daily

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The purpose of this repository is to automate the creation of Synthetic Monitors
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | 1.3.6 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | 1.3.7 |
 | <a name="requirement_dynatrace"></a> [dynatrace](#requirement\_dynatrace) | 1.16.0 |
 
 ## Providers

--- a/components/dt-availability-dashboards/synthetic_monitor.tf
+++ b/components/dt-availability-dashboards/synthetic_monitor.tf
@@ -18,6 +18,9 @@ resource "dynatrace_http_monitor" "availability" {
     outage_handling {
       global_outage = true
       local_outage  = false
+      global_outage_policy {
+        consecutive_runs = 1
+      }
     }
   }
   tags {

--- a/scripts/helpers.py
+++ b/scripts/helpers.py
@@ -89,7 +89,7 @@ def filter_ingress(data, environment):
         for item in data
         # Filter out PR ingress names
         if not (re.search("-pr-[0-9]{1,5}-", item["metadata"]["name"]))
-        # Filter out all ingress endpoints without "helm.toolkit.fluxcd.io/name" set (Jenkins released).
+        # Filter out ingress endpoints without "helm.toolkit.fluxcd.io/name" (Jenkins)
         and (
             "labels" in item["metadata"]
             and "helm.toolkit.fluxcd.io/name" in item["metadata"]["labels"]

--- a/scripts/helpers.py
+++ b/scripts/helpers.py
@@ -89,11 +89,11 @@ def filter_ingress(data, environment):
         for item in data
         # Filter out PR ingress names
         if not (re.search("-pr-[0-9]{1,5}-", item["metadata"]["name"]))
-        # Filter out all ingress endpoints without "helm.fluxcd.io/antecedent" set.
-        # and (
-        #     "annotations" in item["metadata"]
-        #     and "helm.fluxcd.io/antecedent" in item["metadata"]["annotations"]
-        # )
+        # Filter out all ingress endpoints without "helm.toolkit.fluxcd.io/name" set (Jenkins released).
+        and (
+            "labels" in item["metadata"]
+            and "helm.toolkit.fluxcd.io/name" in item["metadata"]["labels"]
+        )
     ]
 
     data_filtered = [

--- a/scripts/helpers.py
+++ b/scripts/helpers.py
@@ -118,6 +118,9 @@ def filter_ingress(data, environment):
         )
         or (environment == "sbox" and "labs" not in item["metadata"]["namespace"])
         or (environment == "ptlsbox" and "labs" not in item["metadata"]["namespace"])
+        or (environment == "ithc")
+        or (environment == "perftest")
+        or (environment == "aat")
         # End of custom filters
     ]
     return data_filtered

--- a/scripts/helpers.py
+++ b/scripts/helpers.py
@@ -95,7 +95,6 @@ def filter_ingress(data, environment):
             and "helm.toolkit.fluxcd.io/name" in item["metadata"]["labels"]
         )
     ]
-
     data_filtered = [
         {
             "name": item["metadata"]["name"],

--- a/scripts/helpers.py
+++ b/scripts/helpers.py
@@ -90,10 +90,10 @@ def filter_ingress(data, environment):
         # Filter out PR ingress names
         if not (re.search("-pr-[0-9]{1,5}-", item["metadata"]["name"]))
         # Filter out all ingress endpoints without "helm.fluxcd.io/antecedent" set.
-        and (
-            "annotations" in item["metadata"]
-            and "helm.fluxcd.io/antecedent" in item["metadata"]["annotations"]
-        )
+        # and (
+        #     "annotations" in item["metadata"]
+        #     and "helm.fluxcd.io/antecedent" in item["metadata"]["annotations"]
+        # )
     ]
 
     data_filtered = [

--- a/scripts/test_helpers.py
+++ b/scripts/test_helpers.py
@@ -37,7 +37,7 @@ kube_data = {
             "kind": "Ingress",
             "metadata": {
                 "annotations": sample_app["annotations"],
-                "labels": ["sample_app.labels"],
+                "labels": sample_app["labels"],
                 "name": sample_app["name"],
                 "namespace": sample_app["namespace"],
             },

--- a/scripts/test_helpers.py
+++ b/scripts/test_helpers.py
@@ -17,7 +17,7 @@ sample_app = {
     "name": "cnp-sample-app",
     "namespace": "cnp",
     "labels": {"aadpodidbinding": "cnp"},
-    "annotations": {"helm.fluxcd.io/antecedent": "samplevalue"},
+    "annotations": {"meta.helm.sh/release-name": "samplevalue"},
     "spec": {
         "ingressClassName": "traefik-no-proxy",
         "rules": [

--- a/scripts/test_helpers.py
+++ b/scripts/test_helpers.py
@@ -50,7 +50,7 @@ kube_data = {
 class TestHelperResources(unittest.TestCase):
     @patch("sys.stdin", io.StringIO(json.dumps(kube_data)))
     def test_get_kubectl_ingress_stdin(self):
-        """Assert kubectl ingress funciton returning a list"""
+        """Assert kubectl ingress function returning a list"""
         self.assertEqual(get_kubectl_ingress(True, None), kube_data["items"])
 
     def test_filter_ingress(self):

--- a/scripts/test_helpers.py
+++ b/scripts/test_helpers.py
@@ -16,7 +16,7 @@ from helpers import (
 sample_app = {
     "name": "cnp-sample-app",
     "namespace": "cnp",
-    "labels": {"aadpodidbinding": "cnp"},
+    "labels": {"aadpodidbinding": "cnp", "helm.toolkit.fluxcd.io/name": "sampleapp"},
     "annotations": {"meta.helm.sh/release-name": "samplevalue"},
     "spec": {
         "ingressClassName": "traefik-no-proxy",


### PR DESCRIPTION
Antecedent annotation was something set with Helm-Operator in FluxV1 - https://github.com/fluxcd/helm-operator/blob/master/pkg/apis/helm.fluxcd.io/v1/types_helmrelease.go#L20. We have now fully migrated to FluxV2 and lost this annotation. Removing in the meantime as it's breaking for daily builds otherwise

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
