### PR TITLE
Update frequency to every 15 minutes

### DIFF
--- a/components/dt-availability-dashboards/synthetic_monitor.tf
+++ b/components/dt-availability-dashboards/synthetic_monitor.tf
@@ -5,7 +5,7 @@ resource "dynatrace_http_monitor" "availability" {
   }
   enabled   = each.value.enabled
   name      = "${each.value.management_zone_name}-${each.value.name}"
-  frequency = 1
+  frequency = 15
   locations = each.value.locations
   lifecycle {
     # Ignoring changes on tags due to dynatrace populating them outside of the code.


### PR DESCRIPTION
Ask from Dynatrace is that next year we are likely not going to have enough DEM units to support this interval across nonprod


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
