### PR TITLE
Disable HTTP monitor problem alerting

### DIFF
--- a/components/dt-availability-dashboards/synthetic_monitor.tf
+++ b/components/dt-availability-dashboards/synthetic_monitor.tf
@@ -18,9 +18,6 @@ resource "dynatrace_http_monitor" "availability" {
     outage_handling {
       global_outage = false
       local_outage  = false
-      global_outage_policy {
-        consecutive_runs = 1
-      }
     }
   }
   tags {

--- a/components/dt-availability-dashboards/synthetic_monitor.tf
+++ b/components/dt-availability-dashboards/synthetic_monitor.tf
@@ -16,7 +16,7 @@ resource "dynatrace_http_monitor" "availability" {
       enabled = true
     }
     outage_handling {
-      global_outage = true
+      global_outage = false
       local_outage  = false
       global_outage_policy {
         consecutive_runs = 1


### PR DESCRIPTION
We aren't proactively doing anything with generated problems with our SLOs at the minute, but they're generating SNOW incidents and clogging up Dynatrace with alerts.

Once (if) we have an action plan with these problems, we can re-enable this. HTTP monitors are still running and adding to SLO numbers




**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
