### PR TITLE
Include day in maintenance window name to remove duplicated names

### DIFF
--- a/components/dt-availability-dashboards/auto_maintenance_window.tf
+++ b/components/dt-availability-dashboards/auto_maintenance_window.tf
@@ -49,7 +49,7 @@ resource "dynatrace_maintenance" "auto_shutdown_weekends" {
     }
   }
   general_properties {
-    name              = "Cluster power-off in ${var.env} environment on ${titel(lower(each.key))}"
+    name              = "Cluster power-off in ${var.env} environment on ${title(lower(each.key))}"
     description       = "All nonprod envs besides AAT are shutdown out of hours. This maintenance window stops alerting and HTTP monitors for all HTTP monitors in ${var.env} environment"
     type              = "PLANNED"
     disable_synthetic = true

--- a/components/dt-availability-dashboards/auto_maintenance_window.tf
+++ b/components/dt-availability-dashboards/auto_maintenance_window.tf
@@ -49,7 +49,7 @@ resource "dynatrace_maintenance" "auto_shutdown_weekends" {
     }
   }
   general_properties {
-    name              = "Cluster power-off in ${var.env} environment on ${lower(each.key)}"
+    name              = "Cluster power-off in ${var.env} environment on ${titel(lower(each.key))}"
     description       = "All nonprod envs besides AAT are shutdown out of hours. This maintenance window stops alerting and HTTP monitors for all HTTP monitors in ${var.env} environment"
     type              = "PLANNED"
     disable_synthetic = true

--- a/components/dt-availability-dashboards/auto_maintenance_window.tf
+++ b/components/dt-availability-dashboards/auto_maintenance_window.tf
@@ -49,7 +49,7 @@ resource "dynatrace_maintenance" "auto_shutdown_weekends" {
     }
   }
   general_properties {
-    name              = "Cluster power-off in ${var.env} environment on weekends"
+    name              = "Cluster power-off in ${var.env} environment on ${lower(each.key)}"
     description       = "All nonprod envs besides AAT are shutdown out of hours. This maintenance window stops alerting and HTTP monitors for all HTTP monitors in ${var.env} environment"
     type              = "PLANNED"
     disable_synthetic = true


### PR DESCRIPTION
Name of the day in the weekend is not added to the window name, so there is two windows for each environment with the same name, which is confusing in the UI