### PR TITLE
Update logic to using https as a base for platform urls

### DIFF
--- a/scripts/helpers.py
+++ b/scripts/helpers.py
@@ -138,7 +138,7 @@ def format_dt_monitors_yaml(department, data_filtered, environment):
             "requests": [
                 {
                     "url": (
-                        f'{"https" if ("idam" in {item["namespace"]}) else "http"}'
+                        f'{"https" if (".platform.hmcts.net" in {item["host"]}) else "http"}'
                         f'://{item["host"]}/health'
                     ),
                     "description": item["host"],

--- a/scripts/helpers.py
+++ b/scripts/helpers.py
@@ -138,7 +138,7 @@ def format_dt_monitors_yaml(department, data_filtered, environment):
             "requests": [
                 {
                     "url": (
-                        f'{"https" if (".platform.hmcts.net" in item["host"]) else "http"}'
+                        f'{"https" if ("platform.hmcts" in item["host"]) else "http"}'
                         f'://{item["host"]}/health'
                     ),
                     "description": item["host"],

--- a/scripts/helpers.py
+++ b/scripts/helpers.py
@@ -138,7 +138,7 @@ def format_dt_monitors_yaml(department, data_filtered, environment):
             "requests": [
                 {
                     "url": (
-                        f'{"https" if (".platform.hmcts.net" in {item["host"]}) else "http"}'
+                        f'{"https" if (".platform.hmcts.net" in item["host"]) else "http"}'
                         f'://{item["host"]}/health'
                     ),
                     "description": item["host"],

--- a/scripts/test_helpers.py
+++ b/scripts/test_helpers.py
@@ -27,19 +27,19 @@ sample_app = {
         ],
     },
 }
-sample_idam_app = {
-    "name": "idam-sample-app",
-    "namespace": "idam",
+sample_https_app = {
+    "name": "https-sample-https-app",
+    "namespace": "cnp",
     "labels": {
-        "aadpodidbinding": "idam",
-        "helm.toolkit.fluxcd.io/name": "idamsampleapp",
+        "aadpodidbinding": "cnp",
+        "helm.toolkit.fluxcd.io/name": "httpssampleapp",
     },
     "annotations": {"meta.helm.sh/release-name": "samplevalue"},
     "spec": {
         "ingressClassName": "traefik-no-proxy",
         "rules": [
             {
-                "host": "idam-sample-app.internal",
+                "host": "cnp-sample-app.platform.hmcts.net",
             }
         ],
     },
@@ -102,12 +102,12 @@ class TestHelperResources(unittest.TestCase):
             f'http://{filtered_data[0]["host"]}/health',
         )
 
-    def test_format_dt_monitors_yaml_idam_https(self):
+    def test_format_dt_monitors_yaml_https(self):
         filtered_data = [
             {
-                "name": sample_idam_app["name"],
-                "namespace": sample_idam_app["namespace"],
-                "host": sample_idam_app["spec"]["rules"][0]["host"],
+                "name": sample_https_app["name"],
+                "namespace": sample_https_app["namespace"],
+                "host": sample_https_app["spec"]["rules"][0]["host"],
             }
         ]
         formatted_data = format_dt_monitors_yaml("cft", filtered_data, "demo")


### PR DESCRIPTION
This should save us having to update this on case-by-case basis by defaulting to https for apps that are going through .platform domain as per @adusumillipraveen suggestion


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
